### PR TITLE
Sharded config

### DIFF
--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -68,7 +68,8 @@ module Lhm
       end
 
       if options[:throttler]
-        options[:throttler] = Throttler::Factory.create_throttler(options[:throttler])
+        throttler_options = options[:throttler_options] || {}
+        options[:throttler] = Throttler::Factory.create_throttler(options[:throttler], throttler_options)
       else
         options[:throttler] = Lhm.throttler
       end

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -2,6 +2,96 @@ require File.expand_path(File.dirname(__FILE__)) + '/../unit_helper'
 
 require 'lhm/throttler/slave_lag'
 
+describe Lhm::Throttler do
+  include UnitHelper
+
+  describe '#format_hosts' do
+    describe 'with only localhost hosts' do
+      it 'returns no hosts' do
+        assert_equal([], Lhm::Throttler.format_hosts(['localhost:1234', '127.0.0.1:5678']))
+      end
+    end
+
+    describe 'with only remote hosts' do
+      it 'returns remote hosts' do
+        assert_equal(['server.example.com', 'anotherserver.example.com'], Lhm::Throttler.format_hosts(['server.example.com:1234', 'anotherserver.example.com']))
+      end
+    end
+  end
+end
+
+describe Lhm::Throttler::Slave do
+  include UnitHelper
+
+  before :each do
+    def get_config
+      lambda { {'username' => 'user', 'password' => 'pw', 'database' => 'db'} }
+    end
+  end
+
+  describe "#client" do
+    before do
+      class TestMysql2Client
+        def initialize(config)
+          raise Mysql2::Error.new("connection error")
+        end
+      end
+    end
+
+    describe 'on connection error' do
+      it 'logs and returns nil' do
+        test_client = lambda { |config|
+          TestMysql2Client.new(config)
+        }
+        Mysql2::Client.stub :new, test_client do
+          assert_send([Lhm.logger, :info, "Error connecting to slave: connection error"])
+          assert_nil(Lhm::Throttler::Slave.new('slave', lambda { {} }).connection)
+        end
+      end
+    end
+
+    describe 'with proper config' do
+      it "creates a new Mysql2::Client" do
+        client_assertion = lambda { |config|
+          assert_equal(config, {:host => 'slave', :username => 'user', :password => 'pw', :database => 'db'})
+        }
+        Mysql2::Client.stub :new, client_assertion do
+          Lhm::Throttler::Slave.new('slave', get_config)
+        end
+      end
+    end
+  end
+
+  describe "#connection" do
+    before do
+      class Connection
+        def self.query(query)
+          if query == Lhm::Throttler::Slave::SQL_SELECT_MAX_SLAVE_LAG
+            [{'Seconds_Behind_Master' => 20}]
+          elsif query == Lhm::Throttler::Slave::SQL_SELECT_SLAVE_HOSTS
+            [{'host' => '1.1.1.1:80'}]
+          end
+        end
+      end
+
+      @slave = Lhm::Throttler::Slave.new('slave', get_config)
+      @slave.instance_variable_set(:@connection, Connection)
+    end
+
+    describe "#lag" do
+      it "returns the slave lag" do
+        assert_equal([20], @slave.lag)
+      end
+    end
+
+    describe "#slave_hosts" do
+      it "returns the hosts" do
+        assert_equal(['1.1.1.1'], @slave.slave_hosts)
+      end
+    end
+  end
+end
+
 describe Lhm::Throttler::SlaveLag do
   include UnitHelper
 
@@ -62,40 +152,50 @@ describe Lhm::Throttler::SlaveLag do
     end
   end
 
-  describe '#slave_hosts' do
+  describe '#get_slaves' do
     describe 'with no slaves' do
       before do
-        def @throttler.get_slaves
+        def @throttler.master_slave_hosts
           []
         end
       end
 
-      it 'returns no slave hosts' do
-        assert_equal([], @throttler.send(:slave_hosts))
+      it 'returns no slaves' do
+        assert_equal([], @throttler.send(:get_slaves))
       end
     end
 
-    describe 'with only localhost slaves' do
+    describe 'with multiple slaves' do
       before do
-        def @throttler.get_slaves
-          ['localhost:1234', '127.0.0.1:5678']
+        class TestSlave
+          attr_reader :host, :connection
+
+          def initialize(host, get_config)
+            @host = host
+            @connection = 'conn' if @host
+          end
+
+          def slave_hosts
+            if @host == '1.1.1.1'
+              ['1.1.1.2', '1.1.1.3']
+            else
+              nil
+            end
+          end
+        end
+
+        def @throttler.master_slave_hosts
+          ['1.1.1.1', '1.1.1.4']
         end
       end
 
-      it 'returns no slave hosts' do
-        assert_equal([], @throttler.send(:slave_hosts))
-      end
-    end
-
-    describe 'with only remote slaves' do
-      before do
-        def @throttler.get_slaves
-          ['server.example.com:1234', 'anotherserver.example.com']
+      it 'returns the slave instances' do
+        create_slave = lambda { |host, config|
+          TestSlave.new(host, config)
+        }
+        Lhm::Throttler::Slave.stub :new, create_slave do
+          assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
         end
-      end
-
-      it 'returns remote slave hosts' do
-        assert_equal(['server.example.com', 'anotherserver.example.com'], @throttler.send(:slave_hosts))
       end
     end
   end


### PR DESCRIPTION
Not sure how to approach this, so I'm just gonna open a PR in my fork of LHM for now.

This gets the slave lag throttler working with Shopify.  The previous version of this only checked the master's slave, but this will walk the replication chain and check the slave lag for every node in a shard.  I'm not sure if we can get generic enough to merge this to the main soundcloud repo, but I've tested it extensively in Shopify and it works for us for both sharded and master only LHMs.  

At a certain point in the chain, a node ends up replicating to hadoop, etc., and when this tries to connect  a MySql2 error is raised because the credentials we're using don't work there.  We decided the best approach here is to just connect to everything in the chain, and if an error is raised on connection, we simply log it, skip that node, and move on.

The config we get from ActiveRecord will connect to the master shard by default.  To get the config for other shards, I'm getting the shard name from [shopify core](https://github.com/Shopify/shopify/blob/master/lib/sharding/switcher.rb#L32-L34).  In the LHM migration, I pass our `current_shard_name` method (it returns `'shard_1'`, etc), and that'll let us determine what config we should be using.

Comments please
